### PR TITLE
Release/editor history

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -31,7 +31,7 @@ import { PexelsModule } from './pexels/pexels.module';
         return {
           type: 'postgres',
           url: config.get<string>(EnvKeys.DATABASE_URL),
-          ...(isProduction ? { ssl: { rejectUnauthorized: false } } : {}),
+          ...(isProduction ? { ssl: { rejectUnauthorized: true } } : {}),
           autoLoadEntities: true,
           synchronize: !isProduction,
           entities: [__dirname + '/**/*.entity.{js,ts}'],

--- a/apps/api/src/emails/emails.module.ts
+++ b/apps/api/src/emails/emails.module.ts
@@ -35,7 +35,7 @@ import { EmailOpenEventEntity } from './entities/email-open-event.entity';
           },
         },
         defaults: {
-          from: config.get(EnvKeys.SMTP_FROM_EMAIL),
+          from: `${config.get(EnvKeys.SMTP_FROM_NAME)} <${config.get(EnvKeys.SMTP_FROM_EMAIL)}>`,
         },
         template: {
           dir: join(process.cwd(), 'dist', 'emails', 'templates'),

--- a/apps/api/src/emails/emails.service.spec.ts
+++ b/apps/api/src/emails/emails.service.spec.ts
@@ -93,15 +93,6 @@ describe('EmailsService', () => {
         subject: mockEmail.subject,
         template: mockEmail.template,
         context: mockEmail.context,
-        headers: {
-          'X-SMTPAPI': JSON.stringify({
-            filters: {
-              clicktrack: { settings: { enable: 0 } },
-              opentrack: { settings: { enable: 0 } },
-            },
-          }),
-          'X-SendGrid-Bypass-Link-Management': 'true',
-        },
       });
       expect(emailsRepository.save).toHaveBeenCalledWith({
         ...mockEmail,

--- a/apps/api/src/emails/emails.service.ts
+++ b/apps/api/src/emails/emails.service.ts
@@ -34,27 +34,7 @@ export class EmailsService {
 
     try {
       // Use raw nodemailer options to bypass SendGrid tracking
-      await this.mailerService.sendMail({
-        ...sendEmailDto,
-        headers: {
-          'X-SMTPAPI': JSON.stringify({
-            filters: {
-              clicktrack: {
-                settings: {
-                  enable: 0,
-                },
-              },
-              opentrack: {
-                settings: {
-                  enable: 0,
-                },
-              },
-            },
-          }),
-          // Bypass link management
-          'X-SendGrid-Bypass-Link-Management': 'true',
-        },
-      });
+      await this.mailerService.sendMail(sendEmailDto);
 
       const updatedEmail: EmailEntity = {
         ...email,

--- a/apps/api/src/shared/pipes/zod.pipe.ts
+++ b/apps/api/src/shared/pipes/zod.pipe.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
-import { ZodSchema } from 'zod';
+import { ZodIssue, ZodIssueCode, ZodSchema } from 'zod';
 
 @Injectable()
 export class ZodValidationPipe implements PipeTransform {
@@ -9,8 +9,20 @@ export class ZodValidationPipe implements PipeTransform {
     const result = this.schema.safeParse(value);
     if (!result.success)
       throw new BadRequestException(
-        isProduction ? result.error.flatten() : result.error.errors,
+        isProduction
+          ? result.error.flatten()
+          : getZodValidationError(result.error.errors),
       );
     return result.data;
   }
 }
+
+const getZodValidationError = (errors: ZodIssue[]): (string | ZodIssue)[] => {
+  return errors.map((error) => {
+    if (error.code === ZodIssueCode.invalid_type) {
+      return `Invalid type for the property "${error.path.join('.')}". Expected ${error.expected} type but received ${error.received}`;
+    }
+
+    return error;
+  });
+};

--- a/apps/api/src/sites/blocks/blocks.service.ts
+++ b/apps/api/src/sites/blocks/blocks.service.ts
@@ -101,12 +101,7 @@ export class SiteBlocksService {
   async update(
     id: number,
     updateSiteBlockDto: UpdateSiteBlockDto,
-    options?: {
-      replace?: boolean;
-    },
   ): Promise<{ block: SiteBlockEntity }> {
-    const { replace = false } = options ?? {};
-
     const matchedSiteBlock = await this.sitesBlocksRepository.findOne({
       where: {
         id,
@@ -120,7 +115,6 @@ export class SiteBlocksService {
 
     // Disallow direct order updates; instruct to use reorder API
     if (
-      !replace &&
       typeof updateSiteBlockDto.order === 'number' &&
       updateSiteBlockDto.order !== matchedSiteBlock.order
     ) {

--- a/apps/api/src/sites/blocks/blocks.service.ts
+++ b/apps/api/src/sites/blocks/blocks.service.ts
@@ -29,25 +29,6 @@ export class SiteBlocksService {
     siteId: number,
     pageId: number,
   ): Promise<{ block: SiteBlockEntity }> {
-    /**
-     * slug
-     */
-    if (createSiteBlockDto.slug) {
-      const slugExists = await this.sitesBlocksRepository.exists({
-        where: {
-          slug: createSiteBlockDto.slug,
-          site: { id: siteId },
-          page: { id: pageId },
-        },
-      });
-
-      if (slugExists) {
-        throw new BadRequestException(
-          SiteBlockErrors['site-block.duplicate-slug'],
-        );
-      }
-    }
-
     const existingCount = await this.sitesBlocksRepository.count({
       where: { page: { id: pageId } },
     });

--- a/apps/api/src/sites/pages/pages.controller.ts
+++ b/apps/api/src/sites/pages/pages.controller.ts
@@ -7,7 +7,6 @@ import {
   ParseIntPipe,
   Patch,
   Post,
-  Put,
 } from '@nestjs/common';
 import { SitePagesService } from './pages.service';
 import { Roles } from 'src/users/decorators/role.decorator';
@@ -53,17 +52,6 @@ export class SitePagesController {
     updateSitePageDto: UpdateSitePageDto,
   ) {
     return this.sitePagesService.update(id, updateSitePageDto);
-  }
-
-  @Put(':id')
-  replace(
-    @Param('id', ParseIntPipe) id: number,
-    @Body(new ZodValidationPipe(SitePageSchema.partial()))
-    updateSitePageDto: UpdateSitePageDto,
-  ) {
-    return this.sitePagesService.update(id, updateSitePageDto, {
-      replace: true,
-    });
   }
 
   @Delete(':id')

--- a/apps/api/src/sites/pages/pages.controller.ts
+++ b/apps/api/src/sites/pages/pages.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Put,
 } from '@nestjs/common';
 import { SitePagesService } from './pages.service';
 import { Roles } from 'src/users/decorators/role.decorator';
@@ -52,6 +53,17 @@ export class SitePagesController {
     updateSitePageDto: UpdateSitePageDto,
   ) {
     return this.sitePagesService.update(id, updateSitePageDto);
+  }
+
+  @Put(':id')
+  replace(
+    @Param('id', ParseIntPipe) id: number,
+    @Body(new ZodValidationPipe(SitePageSchema.partial()))
+    updateSitePageDto: UpdateSitePageDto,
+  ) {
+    return this.sitePagesService.update(id, updateSitePageDto, {
+      replace: true,
+    });
   }
 
   @Delete(':id')

--- a/apps/api/src/sites/pages/pages.service.ts
+++ b/apps/api/src/sites/pages/pages.service.ts
@@ -29,22 +29,6 @@ export class SitePagesService {
     siteId: number,
   ): Promise<{ page: SitePageEntity }> {
     /**
-     * slug
-     */
-    if (createSitePageDto.slug) {
-      const slugExists = await this.sitesPagesRepository.exists({
-        where: {
-          slug: createSitePageDto.slug,
-          site: { id: siteId },
-        },
-      });
-
-      if (slugExists) {
-        throw new BadRequestException(SiteErrors['site-page.duplicate-slug']);
-      }
-    }
-
-    /**
      * isHome
      */
     if (typeof createSitePageDto.isHome === 'boolean') {

--- a/apps/api/src/sites/sites.service.ts
+++ b/apps/api/src/sites/sites.service.ts
@@ -166,6 +166,19 @@ export class SitesService implements AuthorService {
         );
       }
 
+      const { page: matchedSitePage } = await this.sitePagesService.getById({
+        id: page.id,
+      });
+
+      if (
+        typeof page.order === 'number' &&
+        page.order !== matchedSitePage.order
+      ) {
+        throw new BadRequestException(
+          'Changing page order via update is not allowed. Use the reorder API: POST /sites/:siteId/pages/reorder',
+        );
+      }
+
       for (const block of blocks) {
         const { block: matchedBlock } = await this.siteBlocksService.getById({
           id: block.id,
@@ -199,16 +212,16 @@ export class SitesService implements AuthorService {
       await this.sitePagesService.update(page.id, restPage);
     }
 
-    const newSite: SiteEntity = await this.sitesRepository.save({
-      id,
+    const updatedSite: SiteEntity = await this.sitesRepository.save({
       ...matchedSite,
       ...updateSiteDto,
       meta: updateSiteDto.meta
         ? { ...matchedSite.meta, ...updateSiteDto.meta }
         : matchedSite.meta,
+      id,
     });
     const finalSite = await this.sitesRepository.findOne({
-      where: { id: newSite.id },
+      where: { id: updatedSite.id },
       relations: {
         author: true,
         pages: {

--- a/apps/api/supabase/migrations/20250927123059_release_editor_history.sql
+++ b/apps/api/supabase/migrations/20250927123059_release_editor_history.sql
@@ -1,0 +1,31 @@
+-- Fix: Remove global unique constraint on site_blocks.slug that conflicts with undo/redo
+-- This migration safely removes the global constraint while preserving the per-page constraint
+-- Safe for production as it only removes constraints, doesn't modify data
+
+-- First, check if the global constraint exists and remove it
+DO $$
+BEGIN
+  -- Drop the global unique constraint if it exists
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint 
+    WHERE conname = 'UQ_site_blocks_slug' 
+    AND conrelid = 'public.site_blocks'::regclass
+  ) THEN
+    ALTER TABLE public.site_blocks DROP CONSTRAINT "UQ_site_blocks_slug";
+  END IF;
+  
+  -- Drop the global unique index if it exists
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes 
+    WHERE schemaname = 'public' 
+    AND tablename = 'site_blocks' 
+    AND indexname = 'UQ_site_blocks_slug'
+  ) THEN
+    DROP INDEX IF EXISTS "public"."UQ_site_blocks_slug";
+  END IF;
+END $$;
+
+-- Ensure the per-page constraint exists (should already exist from previous migration)
+-- This is idempotent - won't create if it already exists
+CREATE UNIQUE INDEX IF NOT EXISTS "UQ_site_blocks_slug_per_page" 
+ON public.site_blocks USING btree ("pageId", slug);

--- a/apps/web/app/apis/auth/resend-email.ts
+++ b/apps/web/app/apis/auth/resend-email.ts
@@ -1,0 +1,35 @@
+import { createAxiosInstance } from "@/lib/axios/instance";
+import type { ResendAuthEmailDto } from "@clayout/interface";
+import { type AxiosResponse } from "axios";
+
+/**
+ * POST
+ */
+
+interface PostEndpointParams {}
+
+interface PostQueryParams {}
+
+interface PostBody extends ResendAuthEmailDto {}
+
+interface PostParams extends PostEndpointParams, PostQueryParams, PostBody {}
+
+interface PostResponse {
+  message: string;
+}
+
+export async function postAuthResendEmail(args: {
+  params: PostParams;
+  request?: Request;
+}) {
+  const {
+    params: { key },
+    request,
+  } = args;
+  const axios = createAxiosInstance(request);
+  return await axios.post<
+    PostResponse,
+    AxiosResponse<PostResponse, PostParams>,
+    PostParams
+  >(`/auth/resend-email`, { key });
+}

--- a/apps/web/app/apis/sites/pages/blocks/duplicate.ts
+++ b/apps/web/app/apis/sites/pages/blocks/duplicate.ts
@@ -1,4 +1,5 @@
 import { createAxiosInstance } from "@/lib/axios/instance";
+import type { SiteBlock } from "@clayout/interface";
 import type { AxiosResponse } from "axios";
 
 interface PostEndpointParams {
@@ -14,7 +15,7 @@ interface PostBody {}
 interface PostParams extends PostEndpointParams, PostQueryParams, PostBody {}
 
 interface PostResponse {
-  id: number;
+  block: SiteBlock;
 }
 
 export async function postSiteBlockDuplicate(args: {

--- a/apps/web/app/apis/sites/pages/index.ts
+++ b/apps/web/app/apis/sites/pages/index.ts
@@ -121,41 +121,6 @@ export async function patchSitePages(args: {
 }
 
 /**
- * PUT
- */
-
-interface PutEndpointParams {
-  siteId: number;
-  pageId: number;
-}
-
-interface PutQueryParams {}
-
-interface PutBody extends UpdateSitePageDto {}
-
-interface PutParams extends PutEndpointParams, PutQueryParams, PutBody {}
-
-interface PutResponse {
-  page: SitePageWithRelations;
-}
-
-export async function putSitePages(args: {
-  params: PutParams;
-  request?: Request;
-}) {
-  const {
-    params: { siteId, pageId, ...params },
-    request,
-  } = args;
-  const axios = createAxiosInstance(request);
-  return await axios.put<
-    PutResponse,
-    AxiosResponse<PutResponse, PutBody>,
-    PutBody
-  >(`/sites/${siteId}/pages/${pageId}`, params);
-}
-
-/**
  * DELETE
  */
 

--- a/apps/web/app/apis/sites/pages/index.ts
+++ b/apps/web/app/apis/sites/pages/index.ts
@@ -121,6 +121,41 @@ export async function patchSitePages(args: {
 }
 
 /**
+ * PUT
+ */
+
+interface PutEndpointParams {
+  siteId: number;
+  pageId: number;
+}
+
+interface PutQueryParams {}
+
+interface PutBody extends UpdateSitePageDto {}
+
+interface PutParams extends PutEndpointParams, PutQueryParams, PutBody {}
+
+interface PutResponse {
+  page: SitePageWithRelations;
+}
+
+export async function putSitePages(args: {
+  params: PutParams;
+  request?: Request;
+}) {
+  const {
+    params: { siteId, pageId, ...params },
+    request,
+  } = args;
+  const axios = createAxiosInstance(request);
+  return await axios.put<
+    PutResponse,
+    AxiosResponse<PutResponse, PutBody>,
+    PutBody
+  >(`/sites/${siteId}/pages/${pageId}`, params);
+}
+
+/**
  * DELETE
  */
 

--- a/apps/web/app/lib/zustand/commands.ts
+++ b/apps/web/app/lib/zustand/commands.ts
@@ -1,0 +1,344 @@
+import { BlockSchemaByType } from "@clayout/interface";
+import type { BlockSchema } from "@clayout/interface";
+import { nanoid } from "nanoid";
+
+// ----------------------------------------------------------------------------
+// Command Types and Interfaces
+// ----------------------------------------------------------------------------
+
+const CommandTypes = {
+  UPDATE_BLOCK: "UPDATE_BLOCK",
+  REMOVE_BLOCK: "REMOVE_BLOCK",
+  ADD_BLOCK: "ADD_BLOCK",
+  REORDER_BLOCK: "REORDER_BLOCK",
+  REORDER_BLOCKS: "REORDER_BLOCKS",
+  DUPLICATE_BLOCK: "DUPLICATE_BLOCK",
+} as const;
+
+type CommandType = keyof typeof CommandTypes;
+
+interface Command {
+  readonly id: string;
+  readonly description: string;
+  readonly timestamp: number;
+  readonly type: CommandType;
+
+  execute(): void;
+  undo(): void;
+
+  getAffectedBlocks(): number[];
+  getAffectedPages(): number[];
+}
+
+function createBaseCommand(type: CommandType, description: string): Command {
+  const id = `${type}_${Date.now()}_${nanoid(8)}`;
+  const timestamp = Date.now();
+
+  return {
+    id,
+    description,
+    timestamp,
+    type,
+    execute: () => {
+      throw new Error("execute() must be implemented");
+    },
+    undo: () => {
+      throw new Error("undo() must be implemented");
+    },
+    getAffectedBlocks: () => {
+      throw new Error("getAffectedBlocks() must be implemented");
+    },
+    getAffectedPages: () => {
+      throw new Error("getAffectedPages() must be implemented");
+    },
+  };
+}
+
+// ----------------------------------------------------------------------------
+// History Manager
+// ----------------------------------------------------------------------------
+
+export function createHistoryManager() {
+  let historyByPage: Record<number, Command[]> = {};
+  let currentIndexByPage: Record<number, number> = {};
+  const maxHistorySize = 50;
+  let isExecuting = false; // Prevents recursive execution
+
+  /**
+   * @canUndo
+   * - Must have commands in history for the given page
+   * - Current index must be >= 0 (we've executed at least one command)
+   * - Not currently executing a command
+   */
+  function canUndo(pageId: number): boolean {
+    const history = historyByPage[pageId] || [];
+    const currentIndex = currentIndexByPage[pageId] ?? -1;
+    return !isExecuting && history.length > 0 && currentIndex >= 0;
+  }
+
+  /**
+   * @canRedo
+   * - Must have commands in history for the given page
+   * - Current index must be < history.length - 1 (there are commands after current)
+   * - Not currently executing a command
+   */
+  function canRedo(pageId: number): boolean {
+    const history = historyByPage[pageId] || [];
+    const currentIndex = currentIndexByPage[pageId] ?? -1;
+    return (
+      !isExecuting && history.length > 0 && currentIndex < history.length - 1
+    );
+  }
+
+  /**
+   * @execute
+   * Execute a command and add it to history
+   */
+  function execute(command: Command, pageId: number): void {
+    if (isExecuting) {
+      // Cannot execute command while another command is executing
+      return;
+    }
+
+    isExecuting = true;
+
+    try {
+      // Initialize history for page if it doesn't exist
+      if (!historyByPage[pageId]) {
+        historyByPage[pageId] = [];
+        currentIndexByPage[pageId] = -1;
+      }
+
+      const history = historyByPage[pageId];
+      const currentIndex = currentIndexByPage[pageId];
+
+      // Remove any "future" history if we're not at the end
+      // This happens when user undoes some commands and then performs a new action
+      if (currentIndex < history.length - 1) {
+        historyByPage[pageId] = history.slice(0, currentIndex + 1);
+      }
+
+      // Execute the command
+      command.execute();
+
+      // Add to history
+      historyByPage[pageId].push(command);
+      currentIndexByPage[pageId] = historyByPage[pageId].length - 1;
+
+      // Limit history size
+      if (historyByPage[pageId].length > maxHistorySize) {
+        historyByPage[pageId].shift();
+        currentIndexByPage[pageId]--;
+      }
+    } finally {
+      isExecuting = false;
+    }
+  }
+
+  /**
+   * @undo
+   * Undo the last executed command for the specified page
+   */
+  function undo(
+    pageId: number,
+    getBlocksForPage: (pageId: number) => BlockSchema[]
+  ): BlockSchema[] | null {
+    if (!canUndo(pageId)) {
+      return null;
+    }
+
+    isExecuting = true;
+
+    try {
+      const history = historyByPage[pageId];
+      const currentIndex = currentIndexByPage[pageId];
+      const command = history[currentIndex];
+      command.undo();
+      currentIndexByPage[pageId] = currentIndex - 1;
+      return getBlocksForPage(pageId);
+    } finally {
+      isExecuting = false;
+    }
+  }
+
+  /**
+   * @redo
+   * Redo the next command in history for the specified page
+   */
+  function redo(
+    pageId: number,
+    getBlocksForPage: (pageId: number) => BlockSchema[]
+  ): BlockSchema[] | null {
+    if (!canRedo(pageId)) {
+      return null;
+    }
+
+    isExecuting = true;
+
+    try {
+      const currentIndex = currentIndexByPage[pageId];
+      currentIndexByPage[pageId] = currentIndex + 1;
+      const command = historyByPage[pageId][currentIndexByPage[pageId]];
+      command.execute();
+      return getBlocksForPage(pageId);
+    } finally {
+      isExecuting = false;
+    }
+  }
+
+  /**
+   * @getHistoryState
+   * Get current history state for debugging for the specified page
+   */
+  function getHistoryState(pageId: number) {
+    const history = historyByPage[pageId] || [];
+    const currentIndex = currentIndexByPage[pageId] ?? -1;
+
+    return {
+      totalCommands: history.length,
+      currentIndex: currentIndex,
+      canUndo: canUndo(pageId),
+      canRedo: canRedo(pageId),
+      recentCommands: history.slice(-5).map((cmd) => ({
+        id: cmd.id,
+        type: cmd.type,
+        description: cmd.description,
+        timestamp: cmd.timestamp,
+      })),
+    };
+  }
+
+  /**
+   * @clear
+   * Clear all history for all pages
+   */
+  function clear(): void {
+    historyByPage = {};
+    currentIndexByPage = {};
+  }
+
+  /**
+   * @clearPage
+   * Clear history for a specific page
+   */
+  function clearPage(pageId: number): void {
+    delete historyByPage[pageId];
+    delete currentIndexByPage[pageId];
+  }
+
+  return {
+    execute,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    getHistoryState,
+    clear,
+    clearPage,
+  };
+}
+
+export type HistoryManager = ReturnType<typeof createHistoryManager>;
+
+// ----------------------------------------------------------------------------
+// Concrete Command Implementations
+// ----------------------------------------------------------------------------
+
+export function createUpdateBlockCommand(
+  blockId: number,
+  pageId: number,
+  oldBlock: BlockSchema,
+  newBlock: BlockSchema,
+  updateBlockFn: (
+    blockId: number,
+    type: keyof typeof BlockSchemaByType,
+    updates: Partial<BlockSchema>
+  ) => void
+): Command {
+  return {
+    ...createBaseCommand(CommandTypes.UPDATE_BLOCK, `Update block ${blockId}`),
+    execute: () => {
+      if (newBlock.type) {
+        updateBlockFn(blockId, newBlock.type, newBlock);
+      }
+    },
+    undo: () => {
+      if (oldBlock.type) {
+        updateBlockFn(blockId, oldBlock.type, oldBlock);
+      }
+    },
+    getAffectedBlocks: () => [blockId],
+    getAffectedPages: () => [pageId],
+  };
+}
+
+export function createRemoveBlockCommand(
+  pageId: number,
+  blockId: number,
+  removedBlock: BlockSchema,
+  blockIndex: number, // Position where block was removed
+  removeBlockFn: (pageId: number, blockId: number) => void,
+  addBlockFn: (pageId: number, block: BlockSchema, index: number) => void
+): Command {
+  return {
+    ...createBaseCommand(CommandTypes.REMOVE_BLOCK, `Remove block ${blockId}`),
+    execute: () => {
+      removeBlockFn(pageId, blockId);
+    },
+    undo: () => {
+      // Restore the block at its original position
+      addBlockFn(pageId, removedBlock, blockIndex);
+    },
+    getAffectedBlocks: () => [blockId],
+    getAffectedPages: () => [pageId],
+  };
+}
+
+export function createReorderBlockCommand(
+  pageId: number,
+  oldBlockIds: string[],
+  newBlockIds: string[],
+  reorderBlocksFn: (pageId: number, blockIds: string[]) => void
+): Command {
+  return {
+    ...createBaseCommand(
+      CommandTypes.REORDER_BLOCKS,
+      `Reorder blocks on page ${pageId}`
+    ),
+    execute: () => {
+      reorderBlocksFn(pageId, newBlockIds);
+    },
+    undo: () => {
+      // Restore the original order
+      reorderBlocksFn(pageId, oldBlockIds);
+    },
+    getAffectedBlocks: () => {
+      // Get all unique block IDs from both arrays
+      const allIds = [...new Set([...oldBlockIds, ...newBlockIds])];
+      return allIds.map((id) => parseInt(id));
+    },
+    getAffectedPages: () => [pageId],
+  };
+}
+
+export function createAddBlockCommand(
+  pageId: number,
+  block: BlockSchema,
+  blockIndex: number,
+  addBlockFn: (pageId: number, block: BlockSchema, index: number) => void,
+  removeBlockFn: (pageId: number, blockId: number) => void
+): Command {
+  return {
+    ...createBaseCommand(CommandTypes.ADD_BLOCK, `Add block ${block.id}`),
+    execute: () => {
+      addBlockFn(pageId, block, blockIndex);
+    },
+    undo: () => {
+      if (block.id) {
+        removeBlockFn(pageId, block.id);
+      }
+    },
+    getAffectedBlocks: () => (block.id ? [block.id] : []),
+    getAffectedPages: () => [pageId],
+  };
+}

--- a/apps/web/app/pages/auth/forgot-password.tsx
+++ b/apps/web/app/pages/auth/forgot-password.tsx
@@ -13,8 +13,13 @@ import { useMutation } from "@tanstack/react-query";
 import { getErrorMessage } from "@/lib/axios/getErrorMessage";
 import { toast } from "sonner";
 import { ErrorMessage } from "@/components/ui/typography";
+import { useClientMutation } from "@/lib/react-query/useClientMutation";
+import { postAuthResendEmail } from "@/apis/auth/resend-email";
 
 export default function ForgotPassword() {
+  const { mutateAsync: resendEmail } = useClientMutation({
+    mutationFn: postAuthResendEmail,
+  });
   const {
     mutateAsync: forgotPassword,
     isPending,
@@ -53,6 +58,28 @@ export default function ForgotPassword() {
     },
   });
 
+  const handleResendEmail = async () => {
+    const fn = async () => {
+      await resendEmail({
+        params: {
+          key: "reset-password",
+        },
+      });
+    };
+
+    try {
+      await fn();
+    } catch (e) {
+      const { error } = await handleError(e, {
+        onRetry: fn,
+      });
+
+      if (error) {
+        throw error;
+      }
+    }
+  };
+
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
@@ -66,10 +93,17 @@ export default function ForgotPassword() {
                 </Card.Description>
               </Card.Header>
               <Card.Content>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm text-muted-foreground mb-2">
                   If you registered using your email and password, you will
-                  receive a password reset email.
+                  receive a password reset email. If it doesn't arrive within 5
+                  minutes, check your spam folder or resend it.
                 </p>
+                <button
+                  className="underline underline-offset-4 text-left"
+                  onClick={handleResendEmail}
+                >
+                  Resend email
+                </button>
               </Card.Content>
             </Card.Root>
           ) : (

--- a/apps/web/app/pages/auth/verify.tsx
+++ b/apps/web/app/pages/auth/verify.tsx
@@ -1,6 +1,35 @@
+import { postAuthResendEmail } from "@/apis/auth/resend-email";
 import * as Card from "@/components/ui/card";
+import { handleError } from "@/lib/axios/handleError";
+import { useClientMutation } from "@/lib/react-query/useClientMutation";
 
-export default function SignUp() {
+export default function Verify() {
+  const { mutateAsync: resendEmail } = useClientMutation({
+    mutationFn: postAuthResendEmail,
+  });
+
+  const handleResendEmail = async () => {
+    const fn = async () => {
+      await resendEmail({
+        params: {
+          key: "verify",
+        },
+      });
+    };
+
+    try {
+      await fn();
+    } catch (e) {
+      const { error } = await handleError(e, {
+        onRetry: fn,
+      });
+
+      if (error) {
+        throw error;
+      }
+    }
+  };
+
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
@@ -8,10 +37,17 @@ export default function SignUp() {
           <Card.Root>
             <Card.Header>
               <Card.Title className="text-2xl">Verify Email</Card.Title>
-              <Card.Description>
-                A confirmation email has been sent to your email address. To
-                complete your registration, please verify your email.
+              <Card.Description className="mb-2">
+                We just sent a confirmation email to your inbox. Please verify
+                your email to finish signing up. If it doesn't arrive within 5
+                minutes, check your spam folder or resend it.
               </Card.Description>
+              <button
+                className="underline underline-offset-4 text-left"
+                onClick={handleResendEmail}
+              >
+                Resend email
+              </button>
             </Card.Header>
           </Card.Root>
         </div>

--- a/apps/web/app/pages/sites/:id/editor/block/editor/content/index.tsx
+++ b/apps/web/app/pages/sites/:id/editor/block/editor/content/index.tsx
@@ -9,11 +9,16 @@ import type { BlockEditorProps } from "../types";
 import type { z } from "zod";
 
 export function BlockEditorContent() {
-  const { selectedBlock: block, selectedBlockId } = useSiteContext();
+  const {
+    selectedBlock: block,
+    selectedBlockId,
+    closeBlockEditor,
+  } = useSiteContext();
   const blockSchema = useBlockById(selectedBlockId?.toString() ?? "");
 
   if (!blockSchema || !block) {
-    throw new Error(`blockSchema or block context value not found.`);
+    closeBlockEditor();
+    return null;
   }
 
   const parsedBlock = SiteBlockSchema.parse(blockSchema);

--- a/apps/web/app/pages/sites/:id/editor/block/editor/design/index.tsx
+++ b/apps/web/app/pages/sites/:id/editor/block/editor/design/index.tsx
@@ -9,11 +9,16 @@ import type { BlockEditorProps } from "../types";
 import type { z } from "zod";
 
 export function BlockEditorDesign() {
-  const { selectedBlock: block, selectedBlockId } = useSiteContext();
+  const {
+    selectedBlock: block,
+    selectedBlockId,
+    closeBlockEditor,
+  } = useSiteContext();
   const blockSchema = useBlockById(selectedBlockId?.toString() ?? "");
 
   if (!blockSchema || !block) {
-    throw new Error(`blockSchema or block context value not found.`);
+    closeBlockEditor();
+    return null;
   }
 
   const parsedBlock = SiteBlockSchema.parse(blockSchema);

--- a/apps/web/app/pages/sites/:id/editor/block/editor/hooks/useEditorHistory.ts
+++ b/apps/web/app/pages/sites/:id/editor/block/editor/hooks/useEditorHistory.ts
@@ -13,7 +13,7 @@ import {
 import { postSiteBlockReorder } from "@/apis/sites/pages/blocks/reorder";
 
 export function useEditorHistory() {
-  const { site, selectedPageId } = useSiteContext();
+  const { site, selectedPageId, invalidateSiteCache } = useSiteContext();
   const undo = useUndo();
   const redo = useRedo();
   const canUndo = useCanUndo(selectedPageId || 0);
@@ -84,6 +84,8 @@ export function useEditorHistory() {
             default:
               break;
           }
+
+          await invalidateSiteCache();
         };
 
         try {

--- a/apps/web/app/pages/sites/:id/editor/block/editor/hooks/useEditorHistory.ts
+++ b/apps/web/app/pages/sites/:id/editor/block/editor/hooks/useEditorHistory.ts
@@ -1,0 +1,116 @@
+import { useRef } from "react";
+import { toast } from "sonner";
+import { CommandTypes, type CommandResult } from "@/lib/zustand/commands";
+import { useUndo, useRedo, useCanUndo, useCanRedo } from "@/lib/zustand/editor";
+import { useSiteContext } from "@/pages/sites/:id/contexts/site.context";
+import { handleError } from "@/lib/axios/handleError";
+import { useClientMutation } from "@/lib/react-query/useClientMutation";
+import {
+  deleteSiteBlocks,
+  patchSiteBlocks,
+  postSiteBlocks,
+} from "@/apis/sites/pages/blocks";
+import { postSiteBlockReorder } from "@/apis/sites/pages/blocks/reorder";
+
+export function useEditorHistory() {
+  const { site, selectedPageId } = useSiteContext();
+  const undo = useUndo();
+  const redo = useRedo();
+  const canUndo = useCanUndo(selectedPageId || 0);
+  const canRedo = useCanRedo(selectedPageId || 0);
+  const { mutateAsync: updateBlock } = useClientMutation({
+    mutationFn: patchSiteBlocks,
+  });
+  const { mutateAsync: deleteBlock } = useClientMutation({
+    mutationFn: deleteSiteBlocks,
+  });
+  const { mutateAsync: createBlock } = useClientMutation({
+    mutationFn: postSiteBlocks,
+  });
+  const { mutateAsync: reorderBlock } = useClientMutation({
+    mutationFn: postSiteBlockReorder,
+  });
+
+  const updateDB = useRef(async (result: CommandResult | null) =>
+    toast.promise(
+      async () => {
+        const fn = async () => {
+          if (!site?.id) {
+            throw new Error("siteId is required.");
+          }
+          if (!result) {
+            throw new Error("CommandResult is required.");
+          }
+
+          switch (result.type) {
+            case CommandTypes.UPDATE_BLOCK:
+              await updateBlock({
+                params: {
+                  siteId: site.id,
+                  pageId: result.params.pageId,
+                  blockId: result.params.blockId,
+                  block: result.params.block,
+                },
+              });
+              break;
+            case CommandTypes.REMOVE_BLOCK:
+              await deleteBlock({
+                params: {
+                  siteId: site.id,
+                  pageId: result.params.pageId,
+                  blockId: result.params.blockId,
+                },
+              });
+              break;
+            case CommandTypes.ADD_BLOCK:
+              await createBlock({
+                params: {
+                  siteId: site.id,
+                  pageId: result.params.pageId,
+                  block: result.params.block,
+                },
+              });
+              break;
+            case CommandTypes.REORDER_BLOCK:
+              await reorderBlock({
+                params: {
+                  siteId: site.id,
+                  pageId: result.params.pageId,
+                  sourceId: result.params.sourceBlockId,
+                  targetId: result.params.targetBlockId,
+                },
+              });
+              break;
+            default:
+              break;
+          }
+        };
+
+        try {
+          await fn();
+        } catch (e) {
+          const { error } = await handleError(e, {
+            onRetry: fn,
+          });
+
+          if (error) {
+            throw error;
+          }
+        }
+      },
+      {
+        loading: "Saving changes...",
+        success: "Saved",
+        error: "Failed to save",
+      }
+    )
+  );
+
+  return {
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    updateDB,
+  };
+}

--- a/apps/web/app/pages/sites/:id/editor/block/editor/hooks/useHandleChangeBlock.ts
+++ b/apps/web/app/pages/sites/:id/editor/block/editor/hooks/useHandleChangeBlock.ts
@@ -28,9 +28,9 @@ export function useHandleChangeBlock<K extends keyof typeof BlockSchemaByType>({
   const { mutateAsync } = useClientMutation({
     mutationFn: patchSiteBlocks,
   });
-  const updateBlock = useUpdateBlock();
+  const updateBlockLocally = useUpdateBlock();
 
-  const mutateBlock = useRef(
+  const updateDB = useRef(
     debounce(
       async (params: {
         siteId: number;
@@ -82,14 +82,14 @@ export function useHandleChangeBlock<K extends keyof typeof BlockSchemaByType>({
     /**
      * real-time UI update (w/ zustand)
      */
-    updateBlock(block.id, block.type, {
+    updateBlockLocally(block.id, block.type, {
       containerStyle: value,
     });
 
     /**
      * debounced DB update (w/ API request)
      */
-    await mutateBlock.current({
+    await updateDB.current({
       siteId: site.id,
       pageId: selectedPageId,
       block: {
@@ -107,14 +107,14 @@ export function useHandleChangeBlock<K extends keyof typeof BlockSchemaByType>({
     /**
      * real-time UI update (w/ zustand)
      */
-    updateBlock(block.id, block.type, {
+    updateBlockLocally(block.id, block.type, {
       data: value,
     });
 
     /**
      * debounced DB update (w/ API request)
      */
-    await mutateBlock.current({
+    await updateDB.current({
       siteId: site.id,
       pageId: selectedPageId,
       block: {
@@ -132,14 +132,14 @@ export function useHandleChangeBlock<K extends keyof typeof BlockSchemaByType>({
     /**
      * real-time UI update (w/ zustand)
      */
-    updateBlock(block.id, block.type, {
+    updateBlockLocally(block.id, block.type, {
       style: value,
     });
 
     /**
      * debounced DB update (w/ API request)
      */
-    await mutateBlock.current({
+    await updateDB.current({
       siteId: site.id,
       pageId: selectedPageId,
       block: {

--- a/apps/web/app/pages/sites/:id/editor/block/index.tsx
+++ b/apps/web/app/pages/sites/:id/editor/block/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, type MouseEvent } from "react";
 import { BlockRegistry } from "@clayout/kit";
 import { SiteBlockSchema, type SiteBlock } from "@clayout/interface";
 import {
+  useAddBlock,
   useBlockById,
   useRemoveBlock,
   useReorderBlock,
@@ -54,6 +55,7 @@ export function Block({ blockId, blockIndex }: Props) {
   const blockSchema = useBlockById(blockId);
   const reorderBlocksLocally = useReorderBlock();
   const removeBlocksLocally = useRemoveBlock();
+  const addBlocksLocally = useAddBlock();
   const { mutateAsync: reorderBlocks } = useClientMutation({
     mutationFn: postSiteBlockReorder,
   });
@@ -179,9 +181,16 @@ export function Block({ blockId, blockIndex }: Props) {
           blockId: matchedBlock.id,
         },
       });
+
+      const parsed = SiteBlockSchema.safeParse(response.data.block);
+
+      if (parsed.success) {
+        addBlocksLocally(selectedPage.id, parsed.data);
+      }
+
       await invalidateSiteCache();
 
-      setDuplicatedBlockId(response.data.id);
+      setDuplicatedBlockId(response.data.block.id);
     };
 
     try {
@@ -260,8 +269,7 @@ export function Block({ blockId, blockIndex }: Props) {
 
   /**
    * @useEffect
-   * Open duplicated block in the editor
-   * after some amount of delay
+   * Open duplicated block in the editor after some amount of delay
    * because the site data isn't updated right after duplication success
    */
   useEffect(() => {

--- a/apps/web/app/pages/sites/:id/editor/block/index.tsx
+++ b/apps/web/app/pages/sites/:id/editor/block/index.tsx
@@ -53,10 +53,10 @@ export function Block({ blockId, blockIndex }: Props) {
     invalidateSiteCache,
   } = useSiteContext();
   const blockSchema = useBlockById(blockId);
-  const reorderBlocksLocally = useReorderBlock();
-  const removeBlocksLocally = useRemoveBlock();
-  const addBlocksLocally = useAddBlock();
-  const { mutateAsync: reorderBlocks } = useClientMutation({
+  const reorderBlockLocally = useReorderBlock();
+  const removeBlockLocally = useRemoveBlock();
+  const addBlockLocally = useAddBlock();
+  const { mutateAsync: reorderBlock } = useClientMutation({
     mutationFn: postSiteBlockReorder,
   });
   const { mutateAsync: duplicateBlock } = useClientMutation({
@@ -92,9 +92,9 @@ export function Block({ blockId, blockIndex }: Props) {
         throw new Error(`siteId and pageId are required.`);
       }
 
-      reorderBlocksLocally(selectedPage.id, matchedBlock.id, targetBlock.id);
+      reorderBlockLocally(selectedPage.id, matchedBlock.id, targetBlock.id);
 
-      await reorderBlocks({
+      await reorderBlock({
         params: {
           siteId: site.id,
           pageId: selectedPage.id,
@@ -185,7 +185,7 @@ export function Block({ blockId, blockIndex }: Props) {
       const parsed = SiteBlockSchema.safeParse(response.data.block);
 
       if (parsed.success) {
-        addBlocksLocally(selectedPage.id, parsed.data);
+        addBlockLocally(selectedPage.id, parsed.data);
       }
 
       await invalidateSiteCache();
@@ -219,7 +219,7 @@ export function Block({ blockId, blockIndex }: Props) {
       }
 
       closeBlockEditor();
-      removeBlocksLocally(selectedPage.id, matchedBlock.id);
+      removeBlockLocally(selectedPage.id, matchedBlock.id);
 
       await deleteBlock({
         params: {

--- a/apps/web/app/pages/sites/:id/editor/header.tsx
+++ b/apps/web/app/pages/sites/:id/editor/header.tsx
@@ -38,17 +38,17 @@ export const Header = forwardRef<HTMLDivElement, {}>(function Header(
   const { undo, redo, canUndo, canRedo, updateDB } = useEditorHistory();
 
   const handleUndo = async () => {
-    if (selectedPageId) {
-      const result = undo(selectedPageId);
-      await updateDB.current(result);
-    }
+    if (!selectedPageId) return;
+
+    const result = undo(selectedPageId);
+    await updateDB.current(result);
   };
 
   const handleRedo = async () => {
-    if (selectedPageId) {
-      const result = redo(selectedPageId);
-      await updateDB.current(result);
-    }
+    if (!selectedPageId) return;
+
+    const result = redo(selectedPageId);
+    await updateDB.current(result);
   };
 
   const handleBack = () => {

--- a/apps/web/app/pages/sites/:id/editor/index.tsx
+++ b/apps/web/app/pages/sites/:id/editor/index.tsx
@@ -4,8 +4,6 @@ import { useLoaderData } from "react-router";
 import { EditorSidebar } from "./sidebar";
 import { EditorViewer } from "./viewer";
 import { SiteContextProvider } from "../contexts/site.context";
-import { useUpdateEditorAuthStatus } from "@/lib/zustand/editor";
-import { useEffect } from "react";
 
 export async function clientLoader() {
   const { meta, error } = await isAuthenticated();
@@ -22,15 +20,6 @@ export async function clientLoader() {
 export default function Editor() {
   const { meta } = useLoaderData<typeof clientLoader>();
   useAuthMeta(meta);
-
-  /**
-   * @useEffect
-   * Set editor auth status to authenticated
-   */
-  const setAuth = useUpdateEditorAuthStatus();
-  useEffect(() => {
-    setAuth("authenticated");
-  }, [setAuth]);
 
   return (
     <SiteContextProvider key="site-context">

--- a/packages/interface/src/errors/site.error.ts
+++ b/packages/interface/src/errors/site.error.ts
@@ -1,3 +1,9 @@
+export const SiteErrors = {
+  "site-page.slug": "site-page.duplicate-slug",
+} as const;
+
+export type SiteError = keyof typeof SiteErrors;
+
 export const SitePageErrors = {
   "site-page.existing-homepage": "site-page.existing-homepage",
   "site-page.no-homepage": "site-page.no-homepage",

--- a/packages/interface/src/schemas/sites/block.schema.ts
+++ b/packages/interface/src/schemas/sites/block.schema.ts
@@ -21,7 +21,7 @@ const siteBlockShapeBase = {
   id: z.number().optional(),
   slug: z.string(),
   name: z.string().optional(),
-  order: z.number(),
+  order: z.number().optional(),
 } satisfies Pick<BlockSchemaObject, "id" | "slug" | "name" | "order">;
 
 const BlockAligns = {

--- a/packages/interface/src/types/auth.type.ts
+++ b/packages/interface/src/types/auth.type.ts
@@ -1,0 +1,3 @@
+export type ResendAuthEmailDto = {
+  key: "verify" | "reset-password";
+};

--- a/packages/interface/src/types/index.ts
+++ b/packages/interface/src/types/index.ts
@@ -7,3 +7,4 @@ export * from "./asset.type";
 export * from "./base.type";
 export * from "./pexels.type";
 export * from "./reorder.type";
+export * from "./auth.type";


### PR DESCRIPTION
## Changes

- [Add editor history state to zustand store](https://github.com/danbileee/clayout/commit/afeffb17a23ff29dc1e65b6783fbde88e6839c6f) (w/ AI)
- [Improve editor history interface](https://github.com/danbileee/clayout/commit/1acd05c28695081e0d6a074f155c53890bed3381)
  - Use `CommandResult` to decide call which API after processing the history locally
- [Change mailer service (sendgrid > mailgun)](https://github.com/danbileee/clayout/commit/feb8bfb75e7943caa7c4a9758d39e05ae026d253)